### PR TITLE
Replace SeasonSelect DESCRIPTORS_LIST with shallow copy

### DIFF
--- a/packages/web/src/lib/components/ui/form/SeasonSelect.svelte
+++ b/packages/web/src/lib/components/ui/form/SeasonSelect.svelte
@@ -18,7 +18,7 @@
 <Select
     bind:value={seasonStr}
     name={"season"}
-    options={DESCRIPTORS_LIST.reverse().map((d) => ({
+    options={DESCRIPTORS_LIST.slice().reverse().map((d) => ({
         value: d.season + "",
         name: d.seasonNameWithYear,
     }))}


### PR DESCRIPTION
Prevents the season selector from reversing an already reversed order when this is called (ex: switch from a team to the events page, notice how the order flips)