### PR TITLE
Tweak RP icon display

### DIFF
--- a/packages/web/src/lib/components/matches/score-modal/rp/RankingPointIcon.svelte
+++ b/packages/web/src/lib/components/matches/score-modal/rp/RankingPointIcon.svelte
@@ -26,7 +26,7 @@
     height: 1em;
     display: inline-block;
     background-image: url(https://ftc-events-cdn.global-prod.ftclive.org/evtwebextFTC/artifact-CfRTbLAy.svg);
-    background-size: cover;
+    background-size: contain;
     background-position: center;
     background-repeat: no-repeat;
     color: #fff;
@@ -40,9 +40,10 @@
             style="    position: relative;
 width: 3em;
 height: 1em;
+margin: .06em;
 display: inline-block;
 background-image: url(https://ftc-events-cdn.global-prod.ftclive.org/evtwebextFTC/artifact-CfRTbLAy.svg), url(https://ftc-events-cdn.global-prod.ftclive.org/evtwebextFTC/artifact-CfRTbLAy.svg), url(https://ftc-events-cdn.global-prod.ftclive.org/evtwebextFTC/artifact-CfRTbLAy.svg);
-background-size: .5em .5em, .5em .5em, .5em .5em;
+background-size: .425em .425em, .425em .425em, .425em .425em;
 background-position: left center, center center, right center;
 background-repeat: no-repeat;
 color: #fff;


### PR DESCRIPTION
Pretty minor tweak to the RP icon display.  The `goalRp` is no longer slightly cut off, and the `patternRp` now has slight padding (closer matches the scoring system's scoring screen).

<img width="1204" height="696" alt="image" src="https://github.com/user-attachments/assets/914171d9-bc57-46f3-82d2-ca519ff54be0" />
