### PR TITLE
Tweak RP icon background color

### DIFF
--- a/packages/web/src/lib/components/matches/score-modal/rp/RankingPointIcon.svelte
+++ b/packages/web/src/lib/components/matches/score-modal/rp/RankingPointIcon.svelte
@@ -75,11 +75,11 @@ color: #fff;
     }
 
     .red {
-        background: var(--red-team-text-color);
+        background: var(--red-stat-color);
     }
 
     .blue {
-        background: var(--blue-team-text-color);
+        background: var(--blue-stat-color);
     }
 
     .inactive {


### PR DESCRIPTION
The text color was a bit too bright, which looked a bit weird.  This one seems a tad batter.

<img width="1096" height="486" alt="image" src="https://github.com/user-attachments/assets/8a0378c6-9557-44f1-8b65-b1ee4b9d5121" />
