### PR TITLE
Fix tabs jumping when selecting Insights tab

### DIFF
--- a/packages/web/src/lib/components/tabs/TabbedCard.svelte
+++ b/packages/web/src/lib/components/tabs/TabbedCard.svelte
@@ -51,6 +51,8 @@
         gap: var(--md-gap);
         align-items: center;
         justify-content: left;
+        max-width: 1000px;
+        margin: 0 auto;
     }
 
     .tab {


### PR DESCRIPTION
Before: 
<img width="1918" height="813" alt="image" src="https://github.com/user-attachments/assets/bf452709-a3b8-44ad-9bdf-116999798621" />

After: 
<img width="1918" height="813" alt="image" src="https://github.com/user-attachments/assets/6f839442-ceee-4516-b3ce-9081dd66b301" />
