### PR TITLE
Fix Event Search REST API Route

### DIFF
--- a/packages/web/src/routes/api/rest/+page.svelte
+++ b/packages/web/src/routes/api/rest/+page.svelte
@@ -177,7 +177,7 @@
 
             <section>
                 <code class="route">
-                    /events/search?region=<span class="var">RegionOption</span
+                    /events/search/<span class="var">:season</span>?region=<span class="var">RegionOption</span
                     >&ZeroWidthSpace;&type=<span class="var">EventType</span
                     >&ZeroWidthSpace;&hasMatches=<span class="var">Boolean</span
                     >&ZeroWidthSpace;&start=<span class="var">Date</span>&ZeroWidthSpace;&end=<span


### PR DESCRIPTION
fixes issue #41
- changed route from /events/search to /events/search/:season