### PR TITLE
QOL: add team count

### DIFF
--- a/packages/web/src/routes/events/[season=season]/[code]/[tab=event_tab]/+page.svelte
+++ b/packages/web/src/routes/events/[season=season]/[code]/[tab=event_tab]/+page.svelte
@@ -147,7 +147,7 @@
                 [faTrophy, "Rankings", "rankings", !!stats.length],
                 [faBolt, "Insights", "insights", !!insights.length],
                 [faMedal, "Awards", "awards", !!event.awards.length],
-                [faHashtag, "Teams", "teams", !!event.teams.length],
+                [faHashtag, `Teams (${event.teams.length})`, "teams", !!event.teams.length],
             ]}
             bind:selectedTab
         >


### PR DESCRIPTION
Add a frontend value to show the total amount of teams at an event.