### PR TITLE
analytics.ts: Return early if navigator.sendBeacon is not available

### DIFF
--- a/packages/web/src/routes/analytics.ts
+++ b/packages/web/src/routes/analytics.ts
@@ -13,6 +13,7 @@ let timeout: NodeJS.Timeout;
 
 export function sendAnalyticsRequest(navigate: AfterNavigate) {
     if (!browser) return;
+    if (!navigator.sendBeacon) return;
 
     let toUrl = navigate.to?.url;
     if (!toUrl) return;


### PR DESCRIPTION
It's not uncommon for privacy-focused browsers/configs to disable `navigator.sendBeacon` support